### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Port | Start command |
+|---------|------|---------------|
+| Backend (WebSocket) | 8765 | `cd backend && PYTHONPATH=backend python3 server.py` |
+| Frontend (React dev) | 3000 | `cd frontend && BROWSER=none npm start` |
+| Virtual Mixer (OSC) | 2222 UDP | `python3 virtual_mixer/virtual_mixer.py` |
+
+### Running tests
+
+See `CLAUDE.md` for test commands. Key command:
+```
+PYTHONPATH=backend python3 -m pytest tests/ -x --tb=short -q
+```
+
+### Running lint
+
+Frontend ESLint: `cd frontend && npx eslint src/`
+
+### Non-obvious caveats
+
+- **`python` vs `python3`**: The VM only has `python3` on PATH, not `python`. Always use `python3`.
+- **`essentia` package**: Not available for Python 3.12. It is optional and skipped during install. This does not affect tests or normal operation.
+- **`faster-whisper`**: Required by `backend/voice_control.py` but not listed in root `requirements.txt`. Must be installed separately (it is in `backend/requirements.txt`).
+- **System deps**: `portaudio19-dev`, `libsndfile1`, and `python3-dev` are required for PyAudio and audio libraries to compile/install.
+- **Backend uses legacy websockets API**: The server imports `WebSocketServerProtocol` from `websockets.server` (legacy). A deprecation warning is expected.
+- **No mixer needed to start backend**: The backend WebSocket server starts and accepts frontend connections without a physical mixer or virtual mixer running. Mixer connection is initiated from the UI.
+- **Pre-existing test failure**: `tests/test_ml/test_differentiable_console.py::TestDifferentiableMixingConsole::test_forward_returns_mix_and_processed` fails due to shape mismatch (pre-existing, not environment-related).
+- **`~/.local/bin` on PATH**: pip installs scripts to `~/.local/bin`, which may not be on PATH by default. The update script handles this.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for future agents.

### What's included

- Service overview table (backend, frontend, virtual mixer) with ports and start commands
- Test and lint commands reference
- Non-obvious caveats discovered during environment setup:
  - `python3` vs `python` path availability
  - `essentia` package incompatibility with Python 3.12 (optional, skipped)
  - `faster-whisper` dependency not in root requirements.txt
  - System dependency requirements (`portaudio19-dev`, `libsndfile1`, `python3-dev`)
  - Legacy websockets API deprecation warning
  - Backend starts without mixer connection
  - Pre-existing test failure in `test_differentiable_console.py`

### Environment verification

- **Backend**: WebSocket server starts on port 8765, accepts connections
- **Frontend**: React dev server on port 3000, all tabs render correctly
- **Tests**: 207 passed, 1 pre-existing failure, 9 skipped
- **Lint**: 0 errors, 8 pre-existing warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54290679-12b3-448f-8464-da30c44f9f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54290679-12b3-448f-8464-da30c44f9f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

