### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AUTO-MIXER-Tubeslave
+
+AI-driven automatic mixer for live sound. See `CLAUDE.md` for full project overview, quick-start commands, and safety rules.
+
+## Cursor Cloud specific instructions
+
+### System dependencies (pre-installed in snapshot)
+
+- `portaudio19-dev`, `libsndfile1-dev`, `python3-dev` — required for `pyaudio` and `soundfile` to compile/install.
+
+### Python backend
+
+- Install from root `requirements.txt` (not `backend/requirements.txt` which includes `essentia` — unavailable on Python 3.12).
+- `essentia` does not publish wheels for Python 3.12; it is skipped. All 400+ tests pass without it.
+- PyTorch is installed CPU-only (`--index-url https://download.pytorch.org/whl/cpu`) to save disk/time.
+- `faster-whisper` is required at runtime (imported by `voice_control.py`) but not listed in the root `requirements.txt`; the update script installs it explicitly.
+- Run backend: `cd backend && python3 server.py` (WebSocket on `localhost:8765`).
+
+### Frontend (React)
+
+- Run dev server: `cd frontend && BROWSER=none npm start` (serves on `http://localhost:3000`).
+- The frontend connects to the backend via WebSocket at `ws://localhost:8765`.
+
+### Tests
+
+- `PYTHONPATH=backend python3 -m pytest tests/ -x --tb=short -q` — runs all tests.
+- 1 pre-existing test failure in `test_differentiable_console.py` (`test_forward_returns_mix_and_processed`) — not caused by environment setup.
+- No external services (mixer hardware, Ollama, ChromaDB server) are needed for tests; everything is self-contained with mocks and synthetic signals.
+
+### WebSocket message format
+
+- Messages use `{"type": "<handler_name>"}` (not `"action"`).
+- Handler types are registered in `backend/handlers/__init__.py` from 14 sub-modules.
+
+### Audio in headless VM
+
+- No audio devices are available in the cloud VM (no Dante/SoundGrid). The backend starts and serves WebSocket requests fine without audio hardware.
+- For audio-related testing, use `virtual_mixer/virtual_mixer.py` which simulates the WING OSC API.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions for future cloud agents.

### What's included

- System dependency requirements (`portaudio19-dev`, `libsndfile1-dev`, `python3-dev`)
- Python backend setup notes (CPU-only PyTorch, `essentia` skip on Python 3.12, `faster-whisper` requirement)
- Frontend dev server instructions
- Test running instructions and known pre-existing test failure
- WebSocket message format documentation
- Notes on headless VM audio limitations

### Environment verification

| Service | Command | Result |
|---------|---------|--------|
| Backend (WebSocket) | `cd backend && python3 server.py` | Starts on `localhost:8765` |
| Frontend (React) | `cd frontend && BROWSER=none npm start` | Serves on `http://localhost:3000` |
| Tests | `PYTHONPATH=backend python3 -m pytest tests/` | 400 passed, 1 pre-existing failure, 9 skipped |
| Frontend build | `npx react-scripts build` | Builds successfully |

### Demo

[automixer_frontend_demo.mp4](https://cursor.com/agents/bc-0ba8bdb8-85f4-4401-9497-8ba7a161ddc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fautomixer_frontend_demo.mp4)

Frontend UI showing Connect tab with WING IP configuration:

[Frontend Connect tab](https://cursor.com/agents/bc-0ba8bdb8-85f4-4401-9497-8ba7a161ddc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_connect_tab.webp)

Gate tab with noise gate settings:

[Frontend Gate tab](https://cursor.com/agents/bc-0ba8bdb8-85f4-4401-9497-8ba7a161ddc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_gate_tab.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ba8bdb8-85f4-4401-9497-8ba7a161ddc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ba8bdb8-85f4-4401-9497-8ba7a161ddc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

