### PR TITLE
Skills registry, PipeWire source alias, DifferentiableMixingConsole fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ presets/*.json
 # Config overrides
 config/user_config.json
 
+# Runtime session dumps
+sessions/
+
 # Temporary files
 *.tmp
 *.temp

--- a/backend/audio_capture.py
+++ b/backend/audio_capture.py
@@ -28,6 +28,8 @@ class AudioSourceType(Enum):
     DANTE = "dante"
     SOUNDGRID = "soundgrid"
     SOUNDDEVICE = "sounddevice"
+    # Linux PipeWire/JACK: same capture path as sounddevice (PortAudio → PW).
+    PIPEWIRE = "pipewire"
     TEST_SINE = "test_sine"
     TEST_PINK_NOISE = "test_pink_noise"
     TEST_FILE = "test_file"
@@ -210,7 +212,12 @@ class AudioCapture:
             return
         self._running = True
 
-        if self.source_type in (AudioSourceType.DANTE, AudioSourceType.SOUNDDEVICE, AudioSourceType.SOUNDGRID):
+        if self.source_type in (
+            AudioSourceType.DANTE,
+            AudioSourceType.SOUNDDEVICE,
+            AudioSourceType.SOUNDGRID,
+            AudioSourceType.PIPEWIRE,
+        ):
             if HAS_SOUNDDEVICE:
                 self._start_sounddevice()
             else:

--- a/backend/config_manager.py
+++ b/backend/config_manager.py
@@ -55,6 +55,7 @@ class ConfigManager:
                 'sample_rate': 48000,
                 'block_size': 1024,
                 'channels': 40,
+                # dante | soundgrid | sounddevice | pipewire | test_* | silence
                 'source': 'dante',
                 'device_name': '',
                 'device_type': 'default',

--- a/backend/ml/differentiable_console.py
+++ b/backend/ml/differentiable_console.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 
 
 class DifferentiableGain(nn.Module):
@@ -119,16 +119,30 @@ class DifferentiableMixingConsole(nn.Module):
         self.pan = DifferentiablePan(n_channels)
 
     def forward(self, channels):
-        processed = []
-        for i in range(min(self.n_channels, len(channels))):
+        """Mix a list of per-channel waveforms.
+
+        Each tensor is shaped ``(batch, n_samples)`` or ``(n_samples,)``. All
+        tensors are stacked along the channel dimension (rows) so that EQ,
+        dynamics, and gain use one row per mixer channel. Pan is applied per
+        channel; the mix bus is the sum of stereo images, downmixed to mono.
+        """
+        n = min(self.n_channels, len(channels))
+        rows: List[torch.Tensor] = []
+        for i in range(n):
             x = channels[i]
             if x.dim() == 1:
                 x = x.unsqueeze(0)
-            x = self.eq(x)
-            x = self.compressor(x)
-            x = self.gain(x)
-            processed.append(x)
-        mix = sum(processed)
+            rows.append(x)
+        x = torch.cat(rows, dim=0)
+        x = self.eq(x)
+        x = self.compressor(x)
+        x = self.gain(x)
+        # Pan expects (n_channels, n_samples): one pan parameter per row.
+        stereo = self.pan(x)
+        processed = [stereo[i : i + 1] for i in range(stereo.shape[0])]
+        # Sum stereo images across channels, then mono downmix (L+R)/2.
+        summed_lr = stereo.sum(dim=0)
+        mix = ((summed_lr[0] + summed_lr[1]) / 2.0).unsqueeze(0)
         return mix, processed
 
     def get_parameters_dict(self):

--- a/backend/server.py
+++ b/backend/server.py
@@ -40,6 +40,7 @@ from backup_channels import backup_channel
 from restore_channels import restore_from_backup_using_client
 from bleed_service import BleedService
 from handlers import register_all_handlers
+from skills import register_builtin_skills
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -145,6 +146,8 @@ class AutoMixerServer:
         
         # Build message-type → handler dispatch table (B15 decomposition)
         self._dispatch = register_all_handlers(self)
+
+        register_builtin_skills()
 
         logger.info(f"AutoMixer Server initialized on {ws_host}:{ws_port}")
     

--- a/backend/skills/__init__.py
+++ b/backend/skills/__init__.py
@@ -1,0 +1,17 @@
+"""
+Optional skill modules for extending automation (soundcheck, analysis hooks).
+
+This is a lightweight in-process registry — not a third-party runtime. Register
+callables at startup or from tests; handlers and agents can resolve them by name.
+"""
+
+from .builtins import register_builtin_skills
+from .registry import SkillContext, list_skills, register_skill, run_skill
+
+__all__ = [
+    "SkillContext",
+    "list_skills",
+    "register_builtin_skills",
+    "register_skill",
+    "run_skill",
+]

--- a/backend/skills/builtins.py
+++ b/backend/skills/builtins.py
@@ -1,0 +1,21 @@
+"""Built-in example skills (optional registration)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .registry import SkillContext, register_skill
+
+logger = logging.getLogger(__name__)
+
+
+async def _skill_ping(_ctx: SkillContext, params: Dict[str, Any]) -> Dict[str, str]:
+    """Health-check skill: returns ok and echoes optional message."""
+    msg = params.get("message", "")
+    return {"status": "ok", "echo": str(msg)}
+
+
+def register_builtin_skills() -> None:
+    """Register default skills (idempotent: overwrites same names)."""
+    register_skill("ping", _skill_ping)

--- a/backend/skills/registry.py
+++ b/backend/skills/registry.py
@@ -1,0 +1,65 @@
+"""
+In-process skill registry for pluggable automation steps.
+
+Skills are plain async callables registered by name. Use for optional workflows
+(e.g. custom soundcheck steps) without pulling in external agent frameworks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+SkillFn = Callable[["SkillContext", Dict[str, Any]], Awaitable[Any]]
+
+
+@dataclass
+class SkillContext:
+    """Opaque bag for server-owned services passed into skills."""
+
+    server: Any = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+_REGISTRY: Dict[str, SkillFn] = {}
+
+
+def register_skill(name: str, fn: SkillFn) -> None:
+    """Register or replace a skill under *name* (non-empty string)."""
+    if not name or not isinstance(name, str):
+        raise ValueError("skill name must be a non-empty string")
+    if not asyncio.iscoroutinefunction(fn):
+        raise TypeError(f"skill {name!r} must be an async callable")
+    _REGISTRY[name] = fn
+    logger.debug("Registered skill %r", name)
+
+
+def get_skill(name: str) -> Optional[SkillFn]:
+    """Return the registered skill or None."""
+    return _REGISTRY.get(name)
+
+
+def list_skills() -> List[str]:
+    """Return sorted skill names."""
+    return sorted(_REGISTRY.keys())
+
+
+async def run_skill(
+    name: str,
+    ctx: SkillContext,
+    params: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Execute a skill by name; raises KeyError if missing."""
+    fn = _REGISTRY.get(name)
+    if fn is None:
+        raise KeyError(f"unknown skill: {name}")
+    return await fn(ctx, params or {})
+
+
+def clear_skills_for_tests() -> None:
+    """Remove all skills (test helper only)."""
+    _REGISTRY.clear()

--- a/config/automixer.yaml
+++ b/config/automixer.yaml
@@ -13,7 +13,8 @@ audio:
   sample_rate: 48000
   block_size: 1024
   channels: 40
-  source: "dante"  # dante, sounddevice, test_sine, test_pink_noise, silence
+  # dante, soundgrid, sounddevice, pipewire (Linux PW/JACK via PortAudio), test_*, silence
+  source: "dante"
   device_name: ""
   buffer_seconds: 5.0
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -132,7 +132,7 @@ audio:
   sample_rate: 48000
   block_size: 1024
   channels: 40
-  source: "dante"  # dante, sounddevice, test_sine, test_pink_noise, silence
+  source: "dante"  # dante, sounddevice, pipewire (Linux), test_sine, test_pink_noise, silence
 ```
 
 ---

--- a/scripts/linux/pipewire_rt_setup.sh
+++ b/scripts/linux/pipewire_rt_setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Linux audio: PipeWire / real-time hints for low-latency capture.
+# Run review steps manually; this script does not modify system files.
+#
+# References: pipewire wiki (rt kit), limits.conf for @audio rtprio/memlock.
+
+set -euo pipefail
+
+echo "=== PipeWire / RT quick check (read-only) ==="
+echo
+
+if command -v pw-cli >/dev/null 2>&1; then
+  echo "--- pw-cli info (if available) ---"
+  pw-cli info 2>/dev/null | head -40 || true
+else
+  echo "pw-cli not found (install pipewire or use distro packages)."
+fi
+
+echo
+echo "--- Current user limits (RLIMIT) ---"
+ulimit -a 2>/dev/null || true
+
+echo
+echo "Suggested manual steps (not executed here):"
+echo "  1. Add user to group 'audio' (and 'pipewire' if your distro uses it)."
+echo "  2. In /etc/security/limits.d/99-audio.conf (example):"
+echo "       @audio   -  rtprio     95"
+echo "       @audio   -  memlock    unlimited"
+echo "  3. Ensure WirePlumber / pipewire-pulse is running; prefer pipewire-jack for JACK apps."
+echo "  4. For this project, capture uses sounddevice/PortAudio — use PW's ALSA or"
+echo "     JACK device that maps to your Dante/virtual card."
+echo "  5. Set AUTOMIXER audio.source to 'pipewire' in config (same code path as sounddevice)."
+echo

--- a/tests/test_infrastructure/test_skills_registry.py
+++ b/tests/test_infrastructure/test_skills_registry.py
@@ -1,0 +1,43 @@
+"""Tests for backend/skills registry."""
+
+import pytest
+
+from skills.registry import (
+    SkillContext,
+    clear_skills_for_tests,
+    list_skills,
+    register_skill,
+    run_skill,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    clear_skills_for_tests()
+    yield
+    clear_skills_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_register_and_run():
+    async def demo(ctx: SkillContext, params: dict):
+        return {"x": params.get("n", 0)}
+
+    register_skill("demo", demo)
+    assert "demo" in list_skills()
+    out = await run_skill("demo", SkillContext(), {"n": 3})
+    assert out == {"x": 3}
+
+
+@pytest.mark.asyncio
+async def test_unknown_skill_raises():
+    with pytest.raises(KeyError):
+        await run_skill("missing", SkillContext(), {})
+
+
+def test_register_rejects_sync_callable():
+    def bad(ctx: SkillContext, params: dict):
+        return 1
+
+    with pytest.raises(TypeError):
+        register_skill("bad", bad)  # type: ignore[arg-type]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR applies practical pieces of the “hybrid backend” workflow discussed (extensibility, Linux audio path, differentiable console correctness) without adding heavy external frameworks.

## Changes

- **Differentiable mixing console**: Fixed `DifferentiableMixingConsole.forward` so channel tensors are stacked correctly, pan is applied per channel, and the mono mix shape matches tests `(1, n_samples)`.
- **Skills / plugins (lightweight)**: Added `backend/skills/` — an in-process async registry (`register_skill`, `run_skill`, `list_skills`) with a built-in `ping` skill registered at server startup. This mirrors the “skills” idea without pulling in OpenClaw or extra dependencies.
- **PipeWire on Linux**: Added `AudioSourceType.PIPEWIRE` (`pipewire` in config) — same capture path as `sounddevice`/PortAudio, documented for PipeWire/JACK device selection.
- **Ops helper**: `scripts/linux/pipewire_rt_setup.sh` prints environment hints for RT/PipeWire (read-only checklist).
- **Repo hygiene**: `sessions/` added to `.gitignore` for runtime dumps.

## Testing

`PYTHONPATH=backend python3 -m pytest tests/ -q` — all passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab9bb576-5a77-4980-a8b0-c6dec795e21a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab9bb576-5a77-4980-a8b0-c6dec795e21a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

