### PR TITLE
Test stem offline CI run

### DIFF
--- a/docs/stem_offline_ci_test_run.md
+++ b/docs/stem_offline_ci_test_run.md
@@ -1,0 +1,17 @@
+# Stem Offline CI Test Run
+
+This branch exists to trigger the `Stem Offline Test` workflow after the workflow was merged into `master`.
+
+Expected artifact:
+
+- `stem-training-loop-result`
+  - `stem_training_fixture.wav`
+  - `stem_training_fixed_mix.wav`
+  - `stem_training_report.json`
+
+Safety expectations:
+
+- `OSC_DISABLED=true`
+- mock splitter only
+- no live audio thread
+- no OSC commands


### PR DESCRIPTION
Creates a minimal docs-only PR to trigger the Stem Offline Test workflow now that the workflow exists in master.

Expected artifact: stem-training-loop-result with fixture WAV, fixed mix WAV, and report JSON.