### PR TITLE
Fix true-peak HF under-read and EQ cut sign inversion

### DIFF
--- a/backend/auto_eq.py
+++ b/backend/auto_eq.py
@@ -1835,7 +1835,10 @@ class EQCorrector:
                     corrections.append(EQBand(
                         band_type='peak',
                         frequency=freq,
-                        gain=gain * min(1.0, max_cut / abs(self.min_gain)),
+                        # max_cut в профиле отрицателен (напр. -6). Без abs()
+                        # множитель min(1.0, -0.5) = -0.5 инвертировал знак и
+                        # превращал cut в boost проблемной частоты.
+                        gain=gain * min(1.0, abs(max_cut) / abs(self.min_gain)),
                         q=q
                     ))
         

--- a/backend/lufs_gain_staging.py
+++ b/backend/lufs_gain_staging.py
@@ -347,9 +347,14 @@ class TruePeakMeter:
     
     def _design_interpolation_filter(self):
         """Проектирование low-pass фильтра для интерполяции."""
-        # FIR фильтр для 4x oversampling
+        # FIR фильтр для 4x oversampling.
+        # firwin нормирует cutoff к Nyquist ПЕРЕДискретизированного сигнала
+        # (fs*oversample). Анти-имиджинг ФНЧ должен стоять на исходном Nyquist
+        # fs/2, то есть cutoff = (fs/2)/(fs*oversample/2) = 1/oversample.
+        # Значение 0.5/oversample сажало фильтр на fs/4 (12 кГц вместо 24 кГц)
+        # и занижало true-peak ВЧ-источников (тарелки/сибилянты) до ~12 дБ.
         num_taps = 49
-        cutoff = 0.5 / self.oversample_factor
+        cutoff = 1.0 / self.oversample_factor
         self.interp_filter = signal.firwin(num_taps, cutoff)
         self.filter_delay = (num_taps - 1) // 2
     

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -112,3 +112,51 @@ class TestEQCorrectionGeneration:
         assert result.peak_freq < 300.0, (
             f"Peak should be near 100 Hz, got {result.peak_freq:.1f}"
         )
+
+
+class TestEQCutSign:
+    """A profile 'cut' frequency must produce a cut (negative gain), never a boost."""
+
+    def test_profile_cut_stays_a_cut(self):
+        """Regression: gain * min(1.0, max_cut/abs(min_gain)) inverted the sign.
+
+        max_cut in a profile is negative (e.g. -6 dB). Without abs() the scale
+        factor min(1.0, -0.5) = -0.5 flipped the computed cut into a boost of
+        exactly the resonance the profile meant to attenuate — the frequencies
+        most likely to feed back or muddy the mix, applied automatically in
+        auto mode.
+        """
+        from auto_eq import EQCorrector, InstrumentProfile, SpectralData
+
+        cut_freq = 1000.0
+        freqs = np.linspace(0.0, 24000.0, 1025)
+        spectrum = np.full_like(freqs, 0.02)
+        spectrum += np.exp(-0.5 * ((freqs - cut_freq) / 150.0) ** 2)  # bump=1.0
+
+        spectral_data = SpectralData(
+            spectrum=spectrum,
+            frequencies=freqs,
+            peak_freq=cut_freq,
+            centroid=cut_freq,
+            rolloff=cut_freq,
+            flatness=0.1,
+            bandwidth=300.0,
+            peaks=[(cut_freq, 1.0)],
+        )
+        profile = InstrumentProfile(
+            name="test",
+            description="synthetic resonance",
+            target_curve=[(20.0, 0.0), (cut_freq, -12.0), (20000.0, 0.0)],
+            cut_frequencies=[(cut_freq, -6.0, 2.0)],
+            boost_frequencies=[],
+        )
+
+        bands = EQCorrector().calculate_correction(spectral_data, profile, sensitivity=1.0)
+
+        cut_bands = [b for b in bands if abs(b.frequency - cut_freq) < 1.0]
+        assert cut_bands, "cut branch did not fire; test setup no longer triggers it"
+        for b in cut_bands:
+            assert b.gain < 0.0, (
+                f"profile cut at {b.frequency:.0f} Hz produced gain {b.gain:+.2f} dB "
+                f"(positive = boost); a declared cut must stay negative"
+            )

--- a/tests/test_true_peak.py
+++ b/tests/test_true_peak.py
@@ -51,6 +51,28 @@ class TestTruePeakMeter:
             f"True peak of -6 dBFS sine should be near -6, got {true_peak_dbtp:.2f}"
         )
 
+    @pytest.mark.parametrize("freq", [8000.0, 12000.0, 16000.0])
+    def test_true_peak_high_frequency_not_underread(self, sample_rate, freq):
+        """A full-scale HF sine below Nyquist must read near 0 dBTP.
+
+        Regression: the interpolation LPF cutoff must sit at the original
+        Nyquist (fs/2), not fs/4. A cutoff of 0.5/oversample put it at ~12 kHz
+        and under-read bright sources (cymbals/sibilants) by up to ~12 dB
+        (16 kHz measured at ~-11.9 dBTP), which would let AGC/gain-correction
+        push the real signal past 0 dBFS into converter clipping.
+        """
+        meter = TruePeakMeter(sample_rate=sample_rate)
+        duration = 0.5
+        t = np.arange(int(sample_rate * duration)) / sample_rate
+        signal = np.sin(2 * np.pi * freq * t).astype(np.float32)
+
+        true_peak_dbtp = meter.process(signal)
+
+        assert -2.0 < true_peak_dbtp < 2.0, (
+            f"Full-scale {freq:.0f} Hz sine should read ~0 dBTP, got "
+            f"{true_peak_dbtp:.2f} (HF under-read invalidates dBTP safety checks)"
+        )
+
     def test_true_peak_silence(self, sample_rate, test_audio_silence):
         """Silence should produce a very low true peak."""
         meter = TruePeakMeter(sample_rate=sample_rate)


### PR DESCRIPTION
Two safety-relevant DSP-correctness defects in the analysis path, each with a regression test proven to fail on the pre-fix code.

## 1. True-peak meter under-reads HF (`backend/lufs_gain_staging.py`)
`firwin` cutoff was `0.5/oversample = 0.125`, placing the anti-imaging low-pass at **fs/4 (~12 kHz)** instead of the original Nyquist **fs/2 (24 kHz)**. Bright sources were under-read by up to ~12 dB — a full-scale 16 kHz sine read **~-11.9 dBTP**. This meter feeds the dBTP checks used for gain staging, so AGC/gain correction could push a real signal past 0 dBFS into converter clipping.

Fix: `cutoff = 1.0/oversample`. Verified numerically — 16 kHz now reads ~+0.3 dBTP; 1 kHz unchanged.

## 2. EQ profile "cut" inverted into a boost (`backend/auto_eq.py`)
`gain * min(1.0, max_cut/abs(min_gain))` with a negative `max_cut` yields a negative scale factor, flipping an intended cut into a **boost** of exactly the resonance the profile meant to attenuate. Reproduced: a -6 dB cut profile emitted **+6.00 dB**.

Fix: `abs(max_cut)`.

## Tests
- `test_true_peak_high_frequency_not_underread[8000/12000/16000]`
- `tests/test_eq.py::TestEQCutSign::test_profile_cut_stays_a_cut`

Both fail on the pre-fix code (12k/16k under-read; EQ emits +6 dB) and pass after. Targeted suite: **20 passed** (test_true_peak, test_eq, test_lufs). Neither fix touches live-write paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)